### PR TITLE
quick adjustment on failed response for getting a user from database - ticket #47

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -105,7 +105,7 @@ class JSONServer(HandleRequests):
                     )
                 else:
                     return self.response(
-                        "user not found, please register",
+                        json.dumps(response_body),
                         status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
                     )
 

--- a/views/user.py
+++ b/views/user.py
@@ -30,9 +30,7 @@ def login_user(user):
 
         if user_from_db is not None:
             response = {"valid": True, "token": user_from_db["id"]}
-            response = {"valid": True, "token": user_from_db["id"]}
         else:
-            response = {"valid": False}
             response = {"valid": False}
 
         return response


### PR DESCRIPTION
ticket #47

• The purpose of this pull request is to change the server response to a failed request to retrieve a user by their email

• Though it sends an error code, the front end still needs an object with a 'valid' key as False so that it can notify the user to try a different email

• This change simply inserts the response body which is a dictionary created from the SQL query, containing the necessary key/value pair required by the frontend to determine the request's success:

```json
{
"valid": False,
}
```

**TESTING**
Run the debugger in the API, and open up post man. Make a GET request to the following url:

http://localhost:8088/users?user_email=xxx

The response body should be the following object:

```json
{
    "valid": false
}
```
This is indicates that the user email was not found in the database and is the correct response to send to the front end