### PR TITLE
updated post/create category response

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -142,12 +142,11 @@ class JSONServer(HandleRequests):
         elif requested_resource == "categories":
             category_data = json.loads(request_body)
 
-            new_category_id = create_category(category_data)
+            new_category = create_category(category_data)
 
-            if new_category_id:
-                response_body = {"id": new_category_id}
+            if new_category:
                 return self.response(
-                    json.dumps(response_body), status.HTTP_201_SUCCESS_CREATED.value
+                    "", status.HTTP_201_SUCCESS_CREATED.value
                 )
             else:
                 return self.response(

--- a/views/category_view.py
+++ b/views/category_view.py
@@ -15,6 +15,7 @@ def create_category(category_data):
     """
     with sqlite3.connect("./db.sqlite3") as conn:
         db_cursor = conn.cursor()
+        conn.row_factory = sqlite3.Row
 
         db_cursor.execute(
             """
@@ -24,9 +25,7 @@ def create_category(category_data):
             (category_data["label"],),
         )
 
-        new_category_id = db_cursor.lastrowid
-
-    return new_category_id
+    return True if db_cursor.rowcount > 0 else False
 
 
 def delete_category(pk):


### PR DESCRIPTION
• The purpose of this pull request is to update the functionality of the Post method for creating a new category, such that it returns a success code confirming creation with no body

• The front end does not require any body to be returned, a status code suffices

* The create_category function was slightly modified to return a boolean to the Post method, and the Post method was modified to return a status code 201 with no boday, if the returned boolean is True

**TEST**
Run the debugger in the API and open postman. Set the method to post and target the categories path in the url. Enter the following object into the body: 
```json
{
    "label": "new category test"
}
```
You should get a "201 Created" response with no body